### PR TITLE
Implement TagCommand

### DIFF
--- a/src/main/java/seedu/address/logic/commands/TagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/TagCommand.java
@@ -1,0 +1,76 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Person;
+import seedu.address.model.tag.Tag;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Adds or modifies tags for a person in the address book.
+ */
+public class TagCommand extends Command {
+
+    public static final String COMMAND_WORD = "tag";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds or modifies tags for a person in the address book. "
+            + "Parameters: INDEX "
+            + "[" + PREFIX_TAG + "TAG]...\n"
+            + "Example: " + COMMAND_WORD + " 1 " + PREFIX_TAG + "friends " + PREFIX_TAG + "owesMoney";
+
+    public static final String MESSAGE_SUCCESS = "Tags added/modified for person: %1$s";
+
+    private final Index targetIndex;
+    private final Set<Tag> tagsToAdd;
+
+    /**
+     * Creates a TagCommand to add or modify tags for the specified person at the given index.
+     */
+    public TagCommand(Index targetIndex, Set<Tag> tagsToAdd) {
+        this.targetIndex = targetIndex;
+        this.tagsToAdd = tagsToAdd;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        List<Person> lastShownList = model.getFilteredPersonList();
+
+        if (targetIndex.getOneBased() < 0 || targetIndex.getOneBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        Person personToEdit = lastShownList.get(targetIndex.getOneBased());
+        Person editedPerson = new Person(personToEdit.getName(), personToEdit.getPhone(),
+                personToEdit.getEmail(), personToEdit.getAddress(), personToEdit.getTags());
+
+        // Add or modify tags
+        editedPerson.getTags().addAll(tagsToAdd);
+
+        model.setPerson(personToEdit, editedPerson);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, editedPerson));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof TagCommand)) {
+            return false;
+        }
+
+        TagCommand otherTagCommand = (TagCommand) other;
+        return targetIndex == otherTagCommand.targetIndex
+                && tagsToAdd.equals(otherTagCommand.tagsToAdd);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/TagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/TagCommandParser.java
@@ -1,0 +1,46 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.TagCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.tag.Tag;
+
+import java.util.Set;
+
+/**
+ * Parses input arguments and creates a new TagCommand object
+ */
+public class TagCommandParser implements Parser<TagCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the TagCommand
+     * and returns a TagCommand object for execution.
+     * @throws ParseException if the user input does not conform to the expected format
+     */
+    public TagCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_TAG);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_TAG)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, TagCommand.MESSAGE_USAGE));
+        }
+
+        //int targetIndex = (int) ParserUtil.parseIndex(argMultimap.getPreamble());
+        Index targetIndex = ParserUtil.parseIndex(argMultimap.getPreamble());
+        Set<Tag> tagsToAdd = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
+
+        return new TagCommand(targetIndex, tagsToAdd);
+    }
+
+    /**
+     * Returns true if the prefix contains a non-empty {@code Optional} value in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix prefix) {
+        return argumentMultimap.getValue(prefix).isPresent();
+    }
+}


### PR DESCRIPTION
Added the `TagCommand` class to allow users to add or modify tags for a person in the address book. The
`TagCommandParser` has been implemented to parse user input for tagging, accepting a person's index or
identifier and one or more tags. This command provides more flexibility for managing person tags.

- Implemented `TagCommand` class
- Created `TagCommandParser` to handle user input
- Updated command usage messages and help
- Tested the `TagCommand` and `TagCommandParser`