### PR TITLE
Make Edit Command Parser with i/ prefix in user input

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_IC_NUMBER;
 
 import java.util.List;
 
@@ -19,11 +18,10 @@ public class DeleteCommand extends Command {
 
     public static final String COMMAND_WORD = "delete";
 
-
-    public static final String MESSAGE_USAGE =
-        COMMAND_WORD + ": Deletes the patient identified by their IC Number.\n"
-            + "Parameters: " + PREFIX_IC_NUMBER + "IC_NUMBER\n" + "Example: " + COMMAND_WORD + " "
-            + PREFIX_IC_NUMBER + "T8472898S";
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Deletes the patient identified by the ic number used in the displayed patient list.\n"
+            + "Parameters: IC Number (must start and end with an alphabet with non negative numbers in between)\n"
+            + "Example: " + COMMAND_WORD + " i/T0000000A";
 
     public static final String MESSAGE_DELETE_PATIENT_SUCCESS = "Deleted Patient: %1$s";
     private final IcNumber icNumber;
@@ -35,9 +33,9 @@ public class DeleteCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        List<Patient> lastShownList = model.getFilteredPatientList();
+        List<Patient> currentPatientList = model.getCurrentPatientList();
 
-        Patient patientToDelete = model.getPatient(icNumber, lastShownList);
+        Patient patientToDelete = model.getPatient(icNumber, currentPatientList);
         model.deletePatient(patientToDelete);
         return new CommandResult(String.format(MESSAGE_DELETE_PATIENT_SUCCESS, Messages.format(patientToDelete)));
     }

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_REQUIRED_COMMAND_NOT_FOUND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_BIRTHDAY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
@@ -11,12 +12,11 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
+import java.util.stream.Stream;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPatientDescriptor;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -29,6 +29,9 @@ import seedu.address.model.tag.Tag;
  * Parses input arguments and creates a new EditCommand object
  */
 public class EditCommandParser implements Parser<EditCommand> {
+    public static final Prefix[] RELEVANT_PREFIXES = new Prefix[]{PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
+            PREFIX_GENDER, PREFIX_IC_NUMBER, PREFIX_BIRTHDAY, PREFIX_ADDRESS, PREFIX_TAG};
+    public static final Prefix[] REQUIRED_PREFIXES = new Prefix[]{PREFIX_IC_NUMBER};
 
     /**
      * Parses the given {@code String} of arguments in the context of the EditCommand
@@ -42,6 +45,15 @@ public class EditCommandParser implements Parser<EditCommand> {
                 PREFIX_ADDRESS, PREFIX_TAG, PREFIX_GENDER, PREFIX_BIRTHDAY, PREFIX_IC_NUMBER);
 
         IcNumber icNumber;
+        if (!areRelevantPrefixesPresent(argMultimap, RELEVANT_PREFIXES) || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
+        }
+
+        // check if required prefixes are present and not empty
+        if (!areRequiredPrefixesPresent(argMultimap, REQUIRED_PREFIXES)) {
+            throw new ParseException(
+                    String.format(MESSAGE_REQUIRED_COMMAND_NOT_FOUND_FORMAT, Arrays.toString(REQUIRED_PREFIXES)));
+        }
 
         try {
             icNumber = ParserUtil.parseIcNumber(argMultimap.getValue(PREFIX_IC_NUMBER).get());
@@ -100,6 +112,11 @@ public class EditCommandParser implements Parser<EditCommand> {
         Collection<String> tagSet = tags.size() == 1 && tags.contains("") ? Collections.emptySet() : tags;
         return Optional.of(ParserUtil.parseTags(tagSet));
     }
+    private static boolean areRequiredPrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... requiredPrefixes) {
+        return Stream.of(requiredPrefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+    private static boolean areRelevantPrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... requiredPrefixes) {
+        return Stream.of(requiredPrefixes).anyMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
 
 }
-

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -12,7 +12,6 @@ import static seedu.address.testutil.TypicalPatients.*;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.Messages;
-import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPatientDescriptor;
 import seedu.address.model.patient.*;
@@ -32,7 +31,7 @@ public class EditCommandParserTest {
     public void parse_missingParts_failure() {
         // no IC specified
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE);
-        assertParseFailure(parser, "edit i/", expectedMessage);
+        assertParseFailure(parser, " i/", expectedMessage);
         //assertParseFailure(parser, VALID_NAME_AMY, MESSAGE_INVALID_FORMAT);
         // no field specified
         //assertParseFailure(parser, "edit i/T0000000A", EditCommand.MESSAGE_NOT_EDITED);
@@ -44,37 +43,37 @@ public class EditCommandParserTest {
     @Test
     public void parse_invalidInputPrefix_failure() {
         // negative index
-        assertParseFailure(parser, "edit i/-5" + NAME_DESC_AMY, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, " i/-5" + NAME_DESC_AMY, MESSAGE_INVALID_FORMAT);
 
         // zero index
-        assertParseFailure(parser, "edit i/0" + NAME_DESC_AMY, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, " i/0" + NAME_DESC_AMY, MESSAGE_INVALID_FORMAT);
 
         // invalid arguments being parsed as preamble
-        assertParseFailure(parser, "edit i/1 some random string", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, " i/1 some random string", MESSAGE_INVALID_FORMAT);
 
         // invalid prefix being parsed as preamble
-        assertParseFailure(parser, "edit i/string", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, " i/string", MESSAGE_INVALID_FORMAT);
     }
 
     @Test
     public void parse_invalidValue_failure() {
-        assertParseFailure(parser, "edit i/T1234567J" + INVALID_NAME_DESC, Name.MESSAGE_CONSTRAINTS); // invalid name
-        assertParseFailure(parser, "edit i/T1234567J" + INVALID_PHONE_DESC, Phone.MESSAGE_CONSTRAINTS); // invalid phone
-        assertParseFailure(parser, "edit i/T1234567J" + INVALID_EMAIL_DESC, Email.MESSAGE_CONSTRAINTS); // invalid email
-        assertParseFailure(parser, "edit i/T1234567J" + INVALID_ADDRESS_DESC, Address.MESSAGE_CONSTRAINTS); // invalid address
-        assertParseFailure(parser, "edit i/T1234567J" + INVALID_TAG_DESC, Tag.MESSAGE_CONSTRAINTS); // invalid tag
+        assertParseFailure(parser, " i/T1234567J" + INVALID_NAME_DESC, Name.MESSAGE_CONSTRAINTS); // invalid name
+        assertParseFailure(parser, " i/T1234567J" + INVALID_PHONE_DESC, Phone.MESSAGE_CONSTRAINTS); // invalid phone
+        assertParseFailure(parser, " i/T1234567J" + INVALID_EMAIL_DESC, Email.MESSAGE_CONSTRAINTS); // invalid email
+        assertParseFailure(parser, " i/T1234567J" + INVALID_ADDRESS_DESC, Address.MESSAGE_CONSTRAINTS); // invalid address
+        assertParseFailure(parser, " i/T1234567J" + INVALID_TAG_DESC, Tag.MESSAGE_CONSTRAINTS); // invalid tag
 
         // invalid phone followed by valid email
-        assertParseFailure(parser, "edit i/T1234567J" + INVALID_PHONE_DESC + EMAIL_DESC_AMY, Phone.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, " i/T1234567J" + INVALID_PHONE_DESC + EMAIL_DESC_AMY, Phone.MESSAGE_CONSTRAINTS);
 
         // while parsing {@code PREFIX_TAG} alone will reset the tags of the {@code Patient} being edited,
         // parsing it together with a valid tag results in error
-        assertParseFailure(parser, "edit i/T1234567J" + TAG_DESC_FRIEND + TAG_DESC_HUSBAND + TAG_EMPTY, Tag.MESSAGE_CONSTRAINTS);
-        assertParseFailure(parser, "edit i/T1234567J" + TAG_DESC_FRIEND + TAG_EMPTY + TAG_DESC_HUSBAND, Tag.MESSAGE_CONSTRAINTS);
-        assertParseFailure(parser, "edit i/T1234567J" + TAG_EMPTY + TAG_DESC_FRIEND + TAG_DESC_HUSBAND, Tag.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, " i/T1234567J" + TAG_DESC_FRIEND + TAG_DESC_HUSBAND + TAG_EMPTY, Tag.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, " i/T1234567J" + TAG_DESC_FRIEND + TAG_EMPTY + TAG_DESC_HUSBAND, Tag.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, " i/T1234567J" + TAG_EMPTY + TAG_DESC_FRIEND + TAG_DESC_HUSBAND, Tag.MESSAGE_CONSTRAINTS);
 
         // multiple invalid values, but only the first invalid value is captured
-        assertParseFailure(parser, "edit i/T1234567J" + INVALID_NAME_DESC + INVALID_EMAIL_DESC + VALID_ADDRESS_AMY + VALID_PHONE_AMY,
+        assertParseFailure(parser, " i/T1234567J" + INVALID_NAME_DESC + INVALID_EMAIL_DESC + VALID_ADDRESS_AMY + VALID_PHONE_AMY,
                 Name.MESSAGE_CONSTRAINTS);
     }
 
@@ -82,7 +81,7 @@ public class EditCommandParserTest {
     public void parse_allFieldsSpecified_success() {
         IcNumber targetIc = AMY.getIcNumber();
         String userInput =
-                "edit i/" + targetIc.toString() + PHONE_DESC_BOB + TAG_DESC_HUSBAND + EMAIL_DESC_AMY + ADDRESS_DESC_AMY
+                " i/" + targetIc.toString() + PHONE_DESC_BOB + TAG_DESC_HUSBAND + EMAIL_DESC_AMY + ADDRESS_DESC_AMY
                         + NAME_DESC_AMY + TAG_DESC_FRIEND;
 
         EditPatientDescriptor descriptor = new EditPatientDescriptorBuilder().withName(VALID_NAME_AMY)
@@ -96,7 +95,7 @@ public class EditCommandParserTest {
     @Test
     public void parse_someFieldsSpecified_success() {
         IcNumber targetIc = AMY.getIcNumber();
-        String userInput = "edit i/" + targetIc.toString() + PHONE_DESC_BOB + EMAIL_DESC_AMY;
+        String userInput = " i/" + targetIc.toString() + PHONE_DESC_BOB + EMAIL_DESC_AMY;
 
         EditPatientDescriptor descriptor = new EditPatientDescriptorBuilder().withPhone(VALID_PHONE_BOB)
                 .withEmail(VALID_EMAIL_AMY).withIcNumber(VALID_IC_NUMBER_AMY).build();
@@ -109,32 +108,32 @@ public class EditCommandParserTest {
     public void parse_oneFieldSpecified_success() {
         // name
         IcNumber targetIc = CARL.getIcNumber();
-        String userInput = "edit i/" + targetIc.toString() + NAME_DESC_AMY;
+        String userInput = " i/" + targetIc.toString() + NAME_DESC_AMY;
         EditCommand.EditPatientDescriptor descriptor = new EditPatientDescriptorBuilder().withName(VALID_NAME_AMY)
                 .withIcNumber(targetIc.toString()).build();
         EditCommand expectedCommand = new EditCommand(targetIc, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // phone
-        userInput = "edit i/" + targetIc.toString() + PHONE_DESC_AMY;
+        userInput = " i/" + targetIc.toString() + PHONE_DESC_AMY;
         descriptor = new EditPatientDescriptorBuilder().withPhone(VALID_PHONE_AMY).withIcNumber(targetIc.toString()).build();
         expectedCommand = new EditCommand(targetIc, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // email
-        userInput = "edit i/" + targetIc.toString() + EMAIL_DESC_AMY;
+        userInput = " i/" + targetIc.toString() + EMAIL_DESC_AMY;
         descriptor = new EditPatientDescriptorBuilder().withEmail(VALID_EMAIL_AMY).withIcNumber(targetIc.toString()).build();
         expectedCommand = new EditCommand(targetIc, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // address
-        userInput = "edit i/" + targetIc.toString() + ADDRESS_DESC_AMY;
+        userInput = " i/" + targetIc.toString() + ADDRESS_DESC_AMY;
         descriptor = new EditPatientDescriptorBuilder().withAddress(VALID_ADDRESS_AMY).withIcNumber(targetIc.toString()).build();
         expectedCommand = new EditCommand(targetIc, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // tags
-        userInput = "edit i/" + targetIc.toString() + TAG_DESC_FRIEND;
+        userInput = " i/" + targetIc.toString() + TAG_DESC_FRIEND;
         descriptor = new EditPatientDescriptorBuilder().withTags(VALID_TAG_FRIEND).withIcNumber(targetIc.toString()).build();
         expectedCommand = new EditCommand(targetIc, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
@@ -147,7 +146,7 @@ public class EditCommandParserTest {
 
         // valid followed by invalid
         IcNumber targetIc = ALICE.getIcNumber();
-        String userInput = "edit i/" + targetIc.toString() + PHONE_DESC_BOB + INVALID_PHONE_DESC; //+PHONE_DESC_BOB;
+        String userInput = " i/" + targetIc.toString() + PHONE_DESC_BOB + INVALID_PHONE_DESC; //+PHONE_DESC_BOB;
 
         assertParseFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
 
@@ -157,7 +156,7 @@ public class EditCommandParserTest {
         //assertParseFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
 
         // multiple valid fields repeated
-        userInput = "edit i/" + targetIc.toString() + PHONE_DESC_AMY + ADDRESS_DESC_AMY + EMAIL_DESC_AMY + TAG_DESC_FRIEND
+        userInput = " i/" + targetIc.toString() + PHONE_DESC_AMY + ADDRESS_DESC_AMY + EMAIL_DESC_AMY + TAG_DESC_FRIEND
                 + PHONE_DESC_AMY + ADDRESS_DESC_AMY + EMAIL_DESC_AMY + TAG_DESC_FRIEND + PHONE_DESC_BOB + ADDRESS_DESC_BOB
                 + EMAIL_DESC_BOB + TAG_DESC_HUSBAND;
 
@@ -165,7 +164,7 @@ public class EditCommandParserTest {
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS));
 
         // multiple invalid values
-        userInput = "edit i/" + targetIc.toString() + INVALID_PHONE_DESC + INVALID_ADDRESS_DESC + INVALID_EMAIL_DESC
+        userInput = " i/" + targetIc.toString() + INVALID_PHONE_DESC + INVALID_ADDRESS_DESC + INVALID_EMAIL_DESC
                 + INVALID_PHONE_DESC + INVALID_ADDRESS_DESC + INVALID_EMAIL_DESC;
 
         assertParseFailure(parser, userInput,
@@ -175,7 +174,7 @@ public class EditCommandParserTest {
     @Test
     public void parse_resetTags_success() {
         IcNumber targetIc = CARL.getIcNumber();
-        String userInput = "edit i/" + targetIc.toString() + TAG_EMPTY;
+        String userInput = " i/" + targetIc.toString() + TAG_EMPTY;
 
         EditPatientDescriptor descriptor = new EditPatientDescriptorBuilder().
                 withTags().withIcNumber(targetIc.toString()).build();


### PR DESCRIPTION
Let's modify the Edit Command Parser and the corresponding test cases to parse raw user inputs without the command word